### PR TITLE
Fix duplicate orders in OrderBook

### DIFF
--- a/core/OrderBook.hpp
+++ b/core/OrderBook.hpp
@@ -36,7 +36,13 @@ namespace engine {
         }
 
         void insert(const Order& o) {
-            std::lock_guard<std::mutex> lock(mtx);  
+            std::lock_guard<std::mutex> lock(mtx);
+
+            if (seen_timestamps.find(o.timestamp) != seen_timestamps.end()) {
+                SAFE_LOG(WARN) << "[Duplicate Order] ts=" << o.timestamp;
+                return;
+            }
+            seen_timestamps.insert(o.timestamp);
 
             if (arena) {
                 if (arena_count >= max_orders) {


### PR DESCRIPTION
## Summary
- prevent duplicate orders from being inserted into `OrderBook`

## Testing
- `cmake ..` *(fails: Could NOT find GTest)*

------
https://chatgpt.com/codex/tasks/task_e_688789302c58832ab2840b25c90d6eb8