### PR TITLE
Validate FixedWindow capacity

### DIFF
--- a/tests/test_fixed_window.cpp
+++ b/tests/test_fixed_window.cpp
@@ -8,6 +8,10 @@
 
 using engine::FixedWindow;
 
+TEST(FixedWindowTest, ZeroCapacityThrows) {
+    EXPECT_THROW(FixedWindow<int> fw(0), std::invalid_argument);
+}
+
 TEST(FixedWindowTest, PushAndRetrieve) {
     FixedWindow<int> fw(3);
     fw.push(10);

--- a/utils/FixedWindow.hpp
+++ b/utils/FixedWindow.hpp
@@ -10,6 +10,7 @@ namespace engine {
     template<typename T>
     class FixedWindow {
         public:
+            // Constructs a window with the given capacity. Capacity must be at least 1.
             explicit FixedWindow(std::size_t capacity);
 
             void push(const T& value);
@@ -27,7 +28,10 @@ namespace engine {
 
         template<typename T>
         FixedWindow<T>::FixedWindow(std::size_t capacity)
-            : buffer(capacity), max_capacity(capacity) {}
+            : buffer(capacity), max_capacity(capacity) {
+            if (capacity == 0)
+                throw std::invalid_argument("FixedWindow: capacity must be at least 1");
+        }
 
         template<typename T>
         void FixedWindow<T>::push(const T& value) {


### PR DESCRIPTION
## Summary
- Ensure `FixedWindow` constructor rejects zero capacity
- Add test verifying that zero capacity throws an exception

## Testing
- `cmake ..` *(fails: Could NOT find GTest)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ab586e104832ab40819dd4e381b7b