### PR TITLE
Remove std::chrono namespace directive from OrderBook

### DIFF
--- a/core/OrderBook.hpp
+++ b/core/OrderBook.hpp
@@ -17,8 +17,6 @@
 #define WARN 2
 #define ERROR 3
 
-using namespace std::chrono;
-
 namespace engine {
 
     class OrderBook {


### PR DESCRIPTION
## Summary
- Remove `using namespace std::chrono` from the OrderBook header to avoid global namespace pollution.

## Testing
- `cmake .. && make -j$(nproc)` *(fails: Could NOT find GTest)*
- `apt-get update` *(fails: repository ... InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ab58cc8d8832a8d95b0a32fcbd77c