### PR TITLE
Add security macros for memory and thread checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,3 +375,10 @@ target_compile_options(test_zero_copy_csv_parser PRIVATE
     -fstack-protector-strong
     -D_FORTIFY_SOURCE=2
 )
+# ---- Security Macros Tests ----
+add_executable(test_security_macros tests/test_security_macros.cpp)
+target_link_libraries(test_security_macros PRIVATE GTest::gtest_main)
+target_include_directories(test_security_macros PRIVATE
+    ${PROJECT_SOURCE_DIR}/tests
+)
+

--- a/tests/security_macros.hpp
+++ b/tests/security_macros.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+#include <fstream>
+#include <thread>
+#include <vector>
+
+inline std::size_t getCurrentRSS() {
+    std::ifstream statm("/proc/self/statm");
+    std::size_t total = 0, resident = 0;
+    statm >> total >> resident;
+    return resident * static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
+}
+
+#define EXPECT_NO_MEMORY_LEAK(code)                                                   \
+    do {                                                                               \
+        std::size_t __before = getCurrentRSS();                                       \
+        { code; }                                                                     \
+        std::size_t __after = getCurrentRSS();                                        \
+        EXPECT_LE(__after, __before) << "Memory leak detected";                      \
+    } while (0)
+
+#define EXPECT_THREAD_SAFE(code, num_threads)                                         \
+    do {                                                                               \
+        auto __expected = code;                                                       \
+        std::vector<decltype(__expected)> __results(num_threads);                     \
+        std::vector<std::thread> __threads;                                           \
+        __threads.reserve(num_threads);                                               \
+        for (int __i = 0; __i < (num_threads); ++__i) {                               \
+            __threads.emplace_back([&, __i]() { __results[__i] = code; });            \
+        }                                                                             \
+        for (auto& __t : __threads) {                                                 \
+            __t.join();                                                               \
+        }                                                                             \
+        for (const auto& __r : __results) {                                           \
+            EXPECT_EQ(__r, __expected) << "Race condition detected";                 \
+        }                                                                             \
+    } while (0)
+

--- a/tests/test_security_macros.cpp
+++ b/tests/test_security_macros.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+#include "security_macros.hpp"
+#include <memory>
+#include <mutex>
+#include <thread>
+
+TEST(SecurityMacros, NoMemoryLeakPass) {
+    EXPECT_NO_MEMORY_LEAK({
+        auto ptr = std::make_unique<int[]>(1024 * 1024);
+        (void)ptr;
+    });
+}
+
+TEST(SecurityMacros, DetectMemoryLeak) {
+    EXPECT_NONFATAL_FAILURE({
+        EXPECT_NO_MEMORY_LEAK({
+            int* leak = new int[1024 * 1024];
+            (void)leak;
+        });
+    }, "Memory leak detected");
+}
+
+TEST(SecurityMacros, ThreadSafePass) {
+    auto safe = []() -> int {
+        int local = 0;
+        for (int i = 0; i < 1000; ++i) {
+            ++local;
+        }
+        return local;
+    };
+    EXPECT_THREAD_SAFE(safe(), 8);
+}
+
+TEST(SecurityMacros, DetectRace) {
+    int counter = 0;
+    auto race = [&]() -> int {
+        int local = counter;
+        for (int i = 0; i < 1000; ++i) {
+            ++local;
+        }
+        counter = local;
+        return counter;
+    };
+    EXPECT_NONFATAL_FAILURE({
+        EXPECT_THREAD_SAFE(race(), 8);
+    }, "Race condition detected");
+}
+


### PR DESCRIPTION
## Summary
- Add `EXPECT_NO_MEMORY_LEAK` and `EXPECT_THREAD_SAFE` macros for tests
- Create tests demonstrating memory-leak and race-condition detection
- Wire new test target into build system

## Testing
- `cmake -S . -B build` *(fails: Could NOT find GTest)*
- `sudo apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689abb3cd72c832aa8a6a443f9506fa1