### PR TITLE
Add static analysis, sanitizers, coverage, and fuzzing CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: '-*,clang-analyzer-*,bugprone-*,performance-*'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang clang-tidy cppcheck lcov gcovr ninja-build libgtest-dev
+          sudo cmake -S /usr/src/gtest -B /usr/src/gtest/build
+          sudo cmake --build /usr/src/gtest/build
+          sudo cp /usr/src/gtest/build/lib/*.a /usr/lib
+      - name: Configure
+        run: cmake -S . -B build -G Ninja -DENABLE_COVERAGE=ON
+      - name: Build
+        run: cmake --build build
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+      - name: clang-tidy
+        run: ./scripts/run-clang-tidy.sh
+      - name: cppcheck
+        run: ./scripts/run-cppcheck.sh
+      - name: Coverage
+        run: ./scripts/run-coverage.sh
+
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+      - name: Build and run fuzzers
+        run: ./fuzz/run_fuzz.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build-fuzz/
 *.exe
 *.o
 *.obj
@@ -6,6 +7,10 @@ build/
 *.log
 *.tmp
 *.json
+*.gcno
+*.gcda
+*.lcov
+coverage.info
 .DS_Store
 CMakeFiles/
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,13 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+option(ENABLE_COVERAGE "Enable coverage reporting" OFF)
+if(ENABLE_COVERAGE)
+  add_compile_options(-fprofile-arcs -ftest-coverage)
+  add_link_options(-fprofile-arcs -ftest-coverage)
+endif()
+
+
 find_package(Threads REQUIRED)
 
 # ========== GIT COMMIT HASH INJECTION ==========
@@ -67,6 +74,31 @@ target_include_directories(ChronoTrade PRIVATE
 )
 
 add_compile_definitions(ENABLE_LOGS=0) # Disable logs by default
+
+function(add_sanitizer_target suffix flags)
+  add_executable(ChronoTrade_${suffix} EXCLUDE_FROM_ALL ${CORE_SRC} main.cpp)
+  target_compile_options(ChronoTrade_${suffix} PRIVATE
+    -Wall -Wextra -Werror -pedantic
+    -fstack-protector-strong
+    -D_FORTIFY_SOURCE=2
+    -fno-omit-frame-pointer
+    ${flags}
+  )
+  target_link_options(ChronoTrade_${suffix} PRIVATE ${flags})
+  target_link_libraries(ChronoTrade_${suffix} PRIVATE Threads::Threads)
+  target_include_directories(ChronoTrade_${suffix} PRIVATE
+    ${PROJECT_SOURCE_DIR}/feed
+    ${PROJECT_SOURCE_DIR}/core
+    ${PROJECT_SOURCE_DIR}/utils
+    ${PROJECT_SOURCE_DIR}/security
+    ${PROJECT_SOURCE_DIR}/threads
+  )
+endfunction()
+
+add_sanitizer_target(asan "-fsanitize=address")
+add_sanitizer_target(tsan "-fsanitize=thread")
+add_sanitizer_target(ubsan "-fsanitize=undefined")
+add_sanitizer_target(cfi "-fsanitize=cfi -flto -fvisibility=hidden")
 
 # ========== GTEST-BASED TESTS ==========
 
@@ -375,3 +407,7 @@ target_compile_options(test_zero_copy_csv_parser PRIVATE
     -fstack-protector-strong
     -D_FORTIFY_SOURCE=2
 )
+option(BUILD_FUZZERS "Build fuzz targets" OFF)
+if(BUILD_FUZZERS)
+  add_subdirectory(fuzz)
+endif()

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(fuzz_csv_parser fuzz_csv_parser.cpp)
+
+target_include_directories(fuzz_csv_parser PRIVATE
+    ${PROJECT_SOURCE_DIR}/feed
+    ${PROJECT_SOURCE_DIR}/core
+    ${PROJECT_SOURCE_DIR}/utils
+)
+
+target_compile_options(fuzz_csv_parser PRIVATE -fsanitize=fuzzer,address)
+target_link_options(fuzz_csv_parser PRIVATE -fsanitize=fuzzer,address)

--- a/fuzz/fuzz_csv_parser.cpp
+++ b/fuzz/fuzz_csv_parser.cpp
@@ -1,0 +1,12 @@
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include "../feed/CSVOrderParser.hpp"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    feed::CSVOrderParser parser;
+    std::string input(reinterpret_cast<const char*>(data), size);
+    auto result = parser.parse(input);
+    (void)result;
+    return 0;
+}

--- a/fuzz/run_fuzz.sh
+++ b/fuzz/run_fuzz.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+BUILD_DIR=build-fuzz
+cmake -S . -B ${BUILD_DIR} -DBUILD_FUZZERS=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+cmake --build ${BUILD_DIR} --target fuzz_csv_parser
+${BUILD_DIR}/fuzz/fuzz_csv_parser -runs=1000

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure build directory with compile commands exists
+if [ ! -f build/compile_commands.json ]; then
+  cmake -S . -B build >/dev/null 2>&1
+fi
+
+files=$(git ls-files '*.cpp')
+clang-tidy -p build --warnings-as-errors='*' $files

--- a/scripts/run-coverage.sh
+++ b/scripts/run-coverage.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ ! -d build ]; then
+  echo "build directory not found" >&2
+  exit 1
+fi
+
+cd build
+# Fail if line coverage below 95%
+gcovr -r .. --exclude='tests' --fail-under-line 95

--- a/scripts/run-cppcheck.sh
+++ b/scripts/run-cppcheck.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ ! -f build/compile_commands.json ]; then
+  cmake -S . -B build >/dev/null 2>&1
+fi
+
+cppcheck --std=c++20 --enable=warning,style,performance,portability --error-exitcode=1 --project=build/compile_commands.json


### PR DESCRIPTION
## Summary
- add clang-tidy and cppcheck scripts for warning-free static analysis
- wire ASAN/TSAN/UBSAN/CFI targets, coverage option, and fuzzer builds into CMake
- configure CI to run linters, tests with coverage, and libFuzzer harnesses

## Testing
- `cmake -S . -B build -DENABLE_COVERAGE=ON` *(failed: Could NOT find GTest)*
- `clang-tidy -p build main.cpp` *(failed: Could not auto-detect compilation database)*
- `./scripts/run-coverage.sh` *(failed: gcovr: command not found)*
- `./fuzz/run_fuzz.sh` *(failed: clang is not a full path and was not found in the PATH)*

------
https://chatgpt.com/codex/tasks/task_e_689abb3d8860832aa4f400356d6a3821