### PR TITLE
Filter coverage directories in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: echo "Build step placeholder"
+
+      - name: Run tests
+        run: echo "Test step placeholder"
+
+      - name: Collect coverage
+        run: |
+          lcov --directory . --capture --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' '*/tests/*' '*/build/*' --output-file coverage_filtered.info
+          lcov --list coverage_filtered.info
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage_filtered.info


### PR DESCRIPTION
## Summary
- add CI workflow with coverage collection
- exclude tests and build directories from coverage and upload filtered report

## Testing
- `python - <<'PY'
import yaml, sys
print('keys:', list(yaml.safe_load(open('.github/workflows/ci.yml')).keys()))
PY` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml >/tmp/pip.log && tail -n 20 /tmp/pip.log` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_689ac7c7364c832a848d59f82edab906