### PR TITLE
Enable formatting of std::thread::id in SecurityAwareLogger

### DIFF
--- a/security/SecurityAwareLogger.hpp
+++ b/security/SecurityAwareLogger.hpp
@@ -13,6 +13,16 @@
 
 #include <openssl/sha.h>
 
+namespace std {
+template <> struct formatter<std::thread::id> : formatter<std::string> {
+    auto format(const std::thread::id &id, format_context &ctx) const {
+        std::ostringstream oss;
+        oss << id;
+        return formatter<std::string>::format(oss.str(), ctx);
+    }
+};
+} // namespace std
+
 namespace security {
 
 class CryptoHasher {


### PR DESCRIPTION
## Summary
- specialize std::formatter for std::thread::id using std::ostringstream
- allow SecurityAwareLogger to format thread IDs via std::format

## Testing
- `cmake ..` *(fails: Could NOT find GTest)*
- `sudo apt-get update` *(fails: repository not signed)*
- `sudo apt-get install -y libgtest-dev` *(fails: package not found)*
- `g++ -std=c++20 -I. /tmp/test.cpp -lssl -lcrypto -pthread && ./a.out`

------
https://chatgpt.com/codex/tasks/task_e_689ac9ac4d10832abdc1f3100b3dd27e