### PR TITLE
Refactor ASCII validation in CSV feed parser

### DIFF
--- a/feed/CSVFeedSource.hpp
+++ b/feed/CSVFeedSource.hpp
@@ -150,9 +150,8 @@ namespace feed {
             std::atomic<bool> stop_flag_;
 
             bool parse_line(const std::string& line, double& price, double& amount, int64_t& timestamp) {
-                // ASCII check moved here
-                for (unsigned char c : line) {
-                    if (c < 32 || c > 126) return false;
+                if (!is_ascii_printable(line)) {
+                    return false;
                 }
 
                 std::istringstream ss(line);


### PR DESCRIPTION
## Summary
- Reuse helper for printable ASCII validation in CSV feed parser

## Testing
- `cmake -S . -B build` *(fails: Could NOT find GTest)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ac9b139e0832a87bd1554dd4a1b88